### PR TITLE
Bedre fix til ePay double ordre

### DIFF
--- a/epay/controllers/front/validation.php
+++ b/epay/controllers/front/validation.php
@@ -17,94 +17,88 @@ class EPayValidationModuleFrontController extends ModuleFrontController
 		$cart = new Cart($id_cart);
         $id_order = Order::getOrderByCartId($id_cart);
 
-        if(Tools::getValue('callback') != "1")
+        $amount = number_format(Tools::getValue('amount') / 100, 2, ".", "");
+        $currency = isset($_GET['currency']) ? $_GET['currency'] : null;
+        $currencyid = Currency::getIdByIsoCodeNum($currency);
+        if (!$currencyid)
         {
-            Tools::redirectLink(__PS_BASE_URI__.'order-confirmation.php?key='.$cart->secure_key.'&id_cart='.(int)$cart->id.'&id_module='.(int)$this->module->id.'&id_order='.(int)$id_order);
+            $currencyid = NULL;
         }
-        else
+        $cardid = Tools::getValue('paymenttype');
+        $cardnopostfix = isset($_GET['cardno']) ? substr($_GET['cardno'],  - 4) : 0;
+        $transfee = isset($_GET['txnfee']) ? $_GET['txnfee'] : 0;
+        $fraud = isset($_GET['fraud']) ? $_GET['fraud'] : 0;
+
+        $mailVars = array();
+
+        $params = $_GET;
+        $var = "";
+
+        foreach($params as $key => $value)
         {
-            $amount = number_format(Tools::getValue('amount') / 100, 2, ".", "");
-            $currency = isset($_GET['currency']) ? $_GET['currency'] : null;
-            $currencyid = Currency::getIdByIsoCodeNum($currency);
-            if (!$currencyid)
+            if($key != "hash")
             {
-                $currencyid = NULL;
+                $mailVars['{epay_' . $key . '}'] = $value;
+                $var .= $value;
             }
-            $cardid = Tools::getValue('paymenttype');
-            $cardnopostfix = isset($_GET['cardno']) ? substr($_GET['cardno'],  - 4) : 0;
-            $transfee = isset($_GET['txnfee']) ? $_GET['txnfee'] : 0;
-            $fraud = isset($_GET['fraud']) ? $_GET['fraud'] : 0;
-
-            $mailVars = array();
-
-            $params = $_GET;
-            $var = "";
-
-            foreach($params as $key => $value)
+            else
             {
-                if($key != "hash")
-                {
-                    $mailVars['{epay_' . $key . '}'] = $value;
-                    $var .= $value;
-                }
-                else
-                {
-                    break;
-                }
+                break;
             }
+        }
 
-            if(strlen(Configuration::get('EPAY_MD5KEY')) > 0)
+        if(strlen(Configuration::get('EPAY_MD5KEY')) > 0)
+        {
+            $genstamp = md5($var . Configuration::get('EPAY_MD5KEY'));
+
+            if($genstamp != $_REQUEST["hash"])
+                die(Tools::displayError('Error in MD5 data! Please review your passwords in both ePay and your Prestashop admin!'));
+        }
+
+        if($cart->OrderExists() == 0 && $this->module->recordTransaction(null, $id_cart, $_GET["txnid"], $cardid, $cardnopostfix, $currency, Tools::getValue('amount'), $transfee, $fraud))
+        {
+            $paymentMethod = $this->module->displayName . ' ('. $this->module->getCardNameById($cardid) .')';
+
+            if($this->module->validateOrder((int)$id_cart, Configuration::get('PS_OS_PAYMENT'), $amount, $paymentMethod, null, $mailVars, $currencyid, false, $cart->secure_key))
             {
-                $genstamp = md5($var . Configuration::get('EPAY_MD5KEY'));
 
-                if($genstamp != $_REQUEST["hash"])
-                    die(Tools::displayError('Error in MD5 data! Please review your passwords in both ePay and your Prestashop admin!'));
-            }
+                $order = new Order($this->module->currentOrder);
 
-            if($cart->OrderExists() == 0)
-            {
-                $paymentMethod = $this->module->displayName . ' ('. $this->module->getCardNameById($cardid) .')';
+                $payment = $order->getOrderPayments();
+                $payment[0]->transaction_id = Tools::getValue('txnid');
+                $payment[0]->amount = $amount;
+                $payment[0]->card_number = 'XXXX XXXX XXXX ' . $cardnopostfix;
+                $payment[0]->card_brand = $this->module->getCardnameById($cardid);
 
-                if($this->module->validateOrder((int)$id_cart, Configuration::get('PS_OS_PAYMENT'), $amount, $paymentMethod, null, $mailVars, $currencyid, false, $cart->secure_key))
+                if($transfee > 0)
                 {
-                    $this->module->recordTransaction(null, $id_cart, $_GET["txnid"], $cardid, $cardnopostfix, $currency, Tools::getValue('amount'), $transfee, $fraud);
+                    $payment[0]->amount = $payment[0]->amount + number_format($transfee / 100, 2, ".", "");
 
-                    $order = new Order($this->module->currentOrder);
-
-                    $payment = $order->getOrderPayments();
-                    $payment[0]->transaction_id = Tools::getValue('txnid');
-                    $payment[0]->amount = $amount;
-                    $payment[0]->card_number = 'XXXX XXXX XXXX ' . $cardnopostfix;
-                    $payment[0]->card_brand = $this->module->getCardnameById($cardid);
-
-                    if($transfee > 0)
+                    if(Configuration::get('EPAY_ADDFEETOSHIPPING'))
                     {
-                        $payment[0]->amount = $payment[0]->amount + number_format($transfee / 100, 2, ".", "");
+                        $order->total_paid = $order->total_paid + number_format($transfee / 100, 2, ".", "");
+                        $order->total_paid_tax_incl = $order->total_paid_tax_incl + number_format($transfee / 100, 2, ".", "");
+                        $order->total_paid_tax_excl = $order->total_paid_tax_excl + number_format($transfee / 100, 2, ".", "");
+                        $order->total_paid_real = $order->total_paid_real + number_format($transfee / 100, 2, ".", "");
+                        $order->total_shipping = $order->total_shipping + number_format($transfee / 100, 2, ".", "");
+                        $order->total_shipping_tax_incl = $order->total_shipping_tax_incl + number_format($transfee / 100, 2, ".", "");
+                        $order->total_shipping_tax_excl = $order->total_shipping_tax_excl + number_format($transfee / 100, 2, ".", "");
+                        $order->save();
 
-                        if(Configuration::get('EPAY_ADDFEETOSHIPPING'))
+                        if($invoice = $payment[0]->getOrderInvoice($this->module->currentOrder))
                         {
-                            $order->total_paid = $order->total_paid + number_format($transfee / 100, 2, ".", "");
-                            $order->total_paid_tax_incl = $order->total_paid_tax_incl + number_format($transfee / 100, 2, ".", "");
-                            $order->total_paid_tax_excl = $order->total_paid_tax_excl + number_format($transfee / 100, 2, ".", "");
-                            $order->total_paid_real = $order->total_paid_real + number_format($transfee / 100, 2, ".", "");
-                            $order->total_shipping = $order->total_shipping + number_format($transfee / 100, 2, ".", "");
-                            $order->total_shipping_tax_incl = $order->total_shipping_tax_incl + number_format($transfee / 100, 2, ".", "");
-                            $order->total_shipping_tax_excl = $order->total_shipping_tax_excl + number_format($transfee / 100, 2, ".", "");
-                            $order->save();
+                            $invoice->total_paid_tax_incl = $invoice->total_paid_tax_incl + number_format($transfee / 100, 2, ".", "");
+                            $invoice->total_paid_tax_excl = $invoice->total_paid_tax_excl + number_format($transfee / 100, 2, ".", "");
+                            $invoice->total_shipping_tax_incl = $invoice->total_shipping_tax_incl + number_format($transfee / 100, 2, ".", "");
+                            $invoice->total_shipping_tax_excl = $invoice->total_shipping_tax_excl + number_format($transfee / 100, 2, ".", "");
 
-                            if($invoice = $payment[0]->getOrderInvoice($this->module->currentOrder))
-                            {
-                                $invoice->total_paid_tax_incl = $invoice->total_paid_tax_incl + number_format($transfee / 100, 2, ".", "");
-                                $invoice->total_paid_tax_excl = $invoice->total_paid_tax_excl + number_format($transfee / 100, 2, ".", "");
-                                $invoice->total_shipping_tax_incl = $invoice->total_shipping_tax_incl + number_format($transfee / 100, 2, ".", "");
-                                $invoice->total_shipping_tax_excl = $invoice->total_shipping_tax_excl + number_format($transfee / 100, 2, ".", "");
-
-                                $invoice->save();
-                            }
+                            $invoice->save();
                         }
                     }
-                    $payment[0]->save();
                 }
+                $payment[0]->save();
+
+                $this->module->updateTransaction($id_cart);
             }
         }
 	}

--- a/epay/epay.php
+++ b/epay/epay.php
@@ -157,6 +157,24 @@ class EPay extends PaymentModule
 
 		return true;
 	}
+	
+	public function updateTransaction($id_cart)
+	{
+		if(!$id_cart)
+			return false;
+
+		$id_order = Order::getOrderByCartId($id_cart);
+		
+		if(!$id_order)
+			return false;
+		
+		$query = 'UPDATE '  . _DB_PREFIX_ . 'epay_transactions SET id_order="' . pSQL($id_order) . '" WHERE id_cart="'.pSQL($id_cart).'"';
+		
+		if(!Db::getInstance()->Execute($query))
+			return false;
+		
+		return true;
+	}
 
 	private function setCaptured($transaction_id, $amount)
 	{


### PR DESCRIPTION
Fix på dobbelt ordre fejl.

Har gjort sådan at kunden også kan oprette en ordre igen (fjernet
if(Tools::getValue('callback') != "1")). Da dette gav fejl hvis ePays
callback var forsinket. Så har jeg tilføjet recordTransaction()
funktionen til tjekket om ordren eksitere, da den returnere false, hvis
der allerde er en ordre med dette transaktions id (primary key i
tabellen). Og til sidste har jeg intoduceret en ny funktion
updateTransaction($id_cart), som tilføjet id_order til rækken i
epay_transactions tabellen.